### PR TITLE
Error handling in exlude zones

### DIFF
--- a/weasley-card.js
+++ b/weasley-card.js
@@ -252,7 +252,8 @@ class WeasleyClockCard extends HTMLElement {
           )
           :  this.lostState;
 	
-        if (this.exclude.includes(this._hass.states["zone." + stateStr].attributes.friendly_name)) {
+        if (this.exclude.includes(stateStr) ||
+      	  this._hass.states["zone." + stateStr] && this._hass.states["zone." + stateStr].attributes && this._hass.states["zone." + stateStr].attributes.friendly_name) {
           stateStr = this.lostState;
 	}
         const stateVelo = state && state.attributes ? (


### PR DESCRIPTION
Building on yesterdays PR #15 , I discovered instabilities when zones or locations didn't have a friendly name. This is now addressed similar to your fix in 0d876e011915eaf3eabfdac7a5ef9f5a913dc6df.
Sorry for the premature PR and thank your for your great work :-)