### PR TITLE
Add RTL language support and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ I decided to make it public so that other (more skillful) people could make use 
 
 ## Installation
 
+### HACS
+
+Use this repository as a custom repository in HACS.
+
+### Manual
+
 1. Copy weasley-card.js to www/custom-lovelace/ in your home assistant folder, along with any particular font you want to use.
 2. Go to Settings -> Dashboards, then hit the three dots to open the custom Resources editor.
 3. Select "JavaScript Module" as the resource type, then add the URL "/local/custom-lovelace/weasley-card.js?v=1" (note if you put the javascript file somewhere other than www/custom-lovelace/ you'll need to modify this accordingly).
@@ -33,7 +39,7 @@ I decided to make it public so that other (more skillful) people could make use 
 7. Add your config, see the example below
 
 
-## Updating
+#### Updating
 
 1. Copy the updated weasley-card.js over the old version
 2. Edit the url in the Resources editor to increment the version number, e.g:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ I decided to make it public so that other (more skillful) people could make use 
 * Hand colour (and text colour on the hands) can be customised for each person
 * Hands animate fairly smoothly between states
 * "Lost" and "Travelling" state text can be customised
+* Supports right-to-left (RTL) languages like Hebrew and other RTL languages
 
 
 ## Installation

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+    "name": "Weasley Card",
+    "render_readme": true,
+    "filename": "weasley-card.js",
+    "content_in_root": true
+  }

--- a/weasley-card.js
+++ b/weasley-card.js
@@ -192,7 +192,7 @@ class WeasleyClockCard extends HTMLElement {
           var startAngle = 0; 
           var inwardFacing = true;
           var kerning = 0; // can adjust kerning using this - maybe automatically adjust it based on text length? 
-          var text = this.isRtlLanguage(locations[num]) ? locations[num] : locations[num].split("").reverse().join("");
+          var text = locations[num].split("").reverse().join("");
           // if we're in the bottom half of the clock then reverse the facing of the text so that it's not upside down
           if (ang > Math.PI / 2 && ang < ((Math.PI * 2) - (Math.PI / 2))) 
           {
@@ -200,6 +200,8 @@ class WeasleyClockCard extends HTMLElement {
             inwardFacing = false;
             text = locations[num];
           }
+
+          text = this.isRtlLanguage(text) ? text.split("").reverse().join("") : text;
 
           // calculate height of the font. Many ways to do this - you can replace with your own!
           var div = document.createElement("div");

--- a/weasley-card.js
+++ b/weasley-card.js
@@ -192,7 +192,7 @@ class WeasleyClockCard extends HTMLElement {
           var startAngle = 0; 
           var inwardFacing = true;
           var kerning = 0; // can adjust kerning using this - maybe automatically adjust it based on text length? 
-          var text = locations[num].split("").reverse().join("");
+          var text = this.isRtlLanguage(locations[num]) ? locations[num] : locations[num].split("").reverse().join("");
           // if we're in the bottom half of the clock then reverse the facing of the text so that it's not upside down
           if (ang > Math.PI / 2 && ang < ((Math.PI * 2) - (Math.PI / 2))) 
           {
@@ -241,7 +241,10 @@ class WeasleyClockCard extends HTMLElement {
       }
   }
 
-
+  isRtlLanguage(text) {
+    const rtlChar = /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
+    return rtlChar.test(text);
+  }
 
   drawTime(ctx, radius, locations, wizards){
       this.targetstate = [];


### PR DESCRIPTION
Enhance the weasley-card component to support right-to-left (RTL) languages, including Hebrew. Update the README to reflect this new feature and add HACS configuration details. Include a new helper function to detect RTL languages and modify the drawing logic accordingly.