### PR TITLE
Add proximity sensor support for detecting travel state

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,3 +15,26 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "plugin"
+
+  validate-version:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Check version consistency
+        run: |
+          # Extract version from repo.json
+          REPO_VERSION=$(jq -r '.wizardclock.version' repo.json)
+          
+          # Extract version from wizard-clock-card.js
+          JS_VERSION=$(grep 'var VERSION = ' wizard-clock-card.js | cut -d'"' -f2)
+          
+          # Compare versions
+          if [ "$REPO_VERSION" != "$JS_VERSION" ]; then
+            echo "Version mismatch!"
+            echo "repo.json version: $REPO_VERSION"
+            echo "wizard-clock-card.js version: $JS_VERSION"
+            exit 1
+          fi
+          
+          echo "Versions match: $REPO_VERSION"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I decided to make it public so that other (more skillful) people could make use 
 
 * Shows the friendly name of the current Zone that a person/entity is located in 
 * If a person/entity isn't in a Zone then it marks that entity as "Lost" (can be customised)
-* If an entity has a velocity of greater than 15 then it marks that entity as "Travelling" (only tested using owntracks - and GPS must be turned on on your phone for velocity to be reported)
+* If an entity has a velocity of greater than 15 or their proximity direction sensor shows movement, it marks that entity as "Travelling" (supports both owntracks velocity and Home Assistant proximity integration)
 * Locations are added dynamically as needed, however you can configure permanently shown locations by adding them to the "locations" list in the config
 * For family members without a phone (or those that don't want to be tracked with owntracks!) it can use the google calendar platform - simply create a calendar with the expected locations of that person as the name of appointments at the appropriate times
 * Font face can be customised (I use "Blackadder" for a suitably wizardy look)
@@ -73,6 +73,7 @@ min_location_slots: 5
 wizards:
   - entity: device_tracker.harrys_phone
     name: Harry
+    proximity_sensor: sensor.home_harry_direction_of_travel
     colour: '#F00'
     textcolour: '#00F'
   - entity: device_tracker.hermiones_phone

--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,6 @@
 {
     "wizardclock": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "remote_location": "https://raw.githubusercontent.com/malcolmrigg/wizard-clock-card/master/wizard-clock-card.js",
       "visit_repo": "https://github.com/malcolmrigg/wizard-clock-card",
       "changelog": "https://github.com/malcolmrigg/wizard-clock-card/releases/latest"

--- a/wizard-clock-card.js
+++ b/wizard-clock-card.js
@@ -1,5 +1,5 @@
 var CARDNAME = "wizard-clock-card";
-var VERSION = "0.8.0";
+var VERSION = "0.9.0";
 
 class WizardClockCard extends HTMLElement {
 
@@ -296,17 +296,24 @@ class WizardClockCard extends HTMLElement {
 
           stateStr = this.lostState;
 	}
+        // Check both velocity and proximity for movement
         const stateVelo = state && state.attributes ? (
           state.attributes.velocity ? state.attributes.velocity : (
             state.attributes.moving ? 16 : 0
-          )) : 0; 
+          )) : 0;
+
+        // New: Check proximity direction sensor if configured
+        const isMovingByProximity = wizards[num].proximity_sensor &&
+          this._hass.states[wizards[num].proximity_sensor] &&
+          ['towards', 'away_from'].includes(this._hass.states[wizards[num].proximity_sensor].state);
+
         var locnum;
         var wizardOffset = ((num-((wizards.length-1)/2)) / wizards.length * 0.6);
         var location = wizardOffset; // default
         for (locnum = 0; locnum < locations.length; locnum++){
           if ((locations[locnum].toLowerCase() == stateStr.toLowerCase()) 
-              || (locations[locnum] == this.travellingState && stateVelo > 15)
-              || (locations[locnum] == this.lostState && stateStr == "not_home" && stateVelo <= 15))
+            || (locations[locnum] == this.travellingState && (stateVelo > 15 || isMovingByProximity))
+            || (locations[locnum] == this.lostState && stateStr == "not_home" && stateVelo <= 15 && !isMovingByProximity))
           {
             location = locnum + wizardOffset;
             break;


### PR DESCRIPTION
Added support for Home Assistant proximity integration to detect travel state alongside the existing owntracks velocity detection. This allows for more accurate travel state detection using proximity direction sensors.

Fix #32